### PR TITLE
Text size options for displaying more entities

### DIFF
--- a/resources/properties.xml
+++ b/resources/properties.xml
@@ -4,6 +4,7 @@
         <property id="password" type="string"></property>
         <property id="group" type="string">group.default_view</property>
         <property id="llat" type="string"></property>
+        <property id="textsize" type="number">1</property>
     </properties>
 
     <strings>
@@ -11,6 +12,9 @@
        <string id="password_title">Password</string>
        <string id="group_title">Visible Group</string>
        <string id="llat_title">Long-Lived Access Token</string>
+       <string id="textsize_title">Text Size</string>
+       <string id="textsize_normal">Normal</string>
+       <string id="textsize_small">Small</string>
     </strings>
 
     <settings>
@@ -25,5 +29,10 @@
         </setting>
         <setting propertyKey="@Properties.llat" title="@Strings.llat_title">
         	<settingConfig type="alphaNumeric"></settingConfig></setting>
+        <setting propertyKey="@Properties.textsize" title="@Strings.textsize_title">
+        	<settingConfig type="list">
+			        <listEntry value="1">@Strings.textsize_normal</listEntry>
+			        <listEntry value="0">@Strings.textsize_small</listEntry>
+			</settingConfig></setting>
     </settings>
 </resources>

--- a/source/HassIQApp.mc
+++ b/source/HassIQApp.mc
@@ -42,11 +42,13 @@ class HassIQApp extends Application.AppBase {
 		var password = getProperty("password");
 		var group = getProperty("group");
 		var llat = getProperty("llat");
+		var textsize = getProperty("textsize");
 
 		state.setHost(host);
 		state.setPassword(password);
 		state.setGroup(group);
 		state.setLlat(llat);
+		state.setTextsize(textsize);
 
 		if (view != null) {
 			view.requestUpdate();

--- a/source/HassIQState.mc
+++ b/source/HassIQState.mc
@@ -15,6 +15,7 @@ class HassIQState {
 	var code = null;
 	var token = null;
 	var llat = null;
+	var textsize = null;
 
 	static var on = "on";
 	static var off = "off";
@@ -49,6 +50,10 @@ class HassIQState {
 		self.llat = llat;
 	}
 
+	function setTextsize(textsize) {
+		self.textsize = textsize;
+	}
+	
 	function setGroup(group) {
 		self.visibilityGroup = group;
 	}
@@ -345,6 +350,13 @@ class HassIQState {
 
 			var title = entity[:name] ? entity[:name] : entity[:entity_id];
 			var color = Graphics.COLOR_WHITE;
+			var font = null;
+			
+			if (textsize == 0) {
+			    font = Graphics.FONT_XTINY;
+			} else {
+			    font = Graphics.FONT_TINY;
+			}
 
 			if (state.length() == 0 || state.equals(off) || state.equals(unknown)) {
 				// Nothing
@@ -358,8 +370,9 @@ class HassIQState {
 			if (entity[:drawable]) {
 				entity[:drawable].setText(title);
 				entity[:drawable].setColor(color);
+				entity[:drawable].setFont(font);
 			} else {
-				drawable = new WatchUi.Text({:text=>title, :font=>Graphics.FONT_TINY, :locX=>WatchUi.LAYOUT_HALIGN_CENTER, :locY=>0, :color=>color});
+				drawable = new WatchUi.Text({:text=>title, :font=>textsize, :locX=>WatchUi.LAYOUT_HALIGN_CENTER, :locY=>0, :color=>color});
 				entity[:drawable] = drawable;
 			}
 		}

--- a/source/HassIQView.mc
+++ b/source/HassIQView.mc
@@ -31,7 +31,13 @@ class HassIQView extends WatchUi.View {
 			var layout = new [size];
 			var count = 0;
 			var height = dc.getHeight();
-			var fontHeight = dc.getFontHeight(Graphics.FONT_TINY);
+			var fontHeight = null;
+			
+			if (state.textsize == 0) {
+			    fontHeight = dc.getFontHeight(Graphics.FONT_XTINY);
+			} else {
+			    fontHeight = dc.getFontHeight(Graphics.FONT_TINY);
+			}
 
 			// Only show as many entities as we have room for
 			for(var i=0; i<size && (count*fontHeight) < height; ++i) {


### PR DESCRIPTION
Sorry about the mess before, Alan!

I have found with these additions to the scripts with the smaller text size I can comfortably fit 9 entities on the status screen at any time. The user can select from either Normal or Small font sizes in the Garmin app and the entities will be refreshed at the new size.

Please let me know if there are any issues!

Thanks

Alasdair