### PR TITLE
Colours for on/off status

### DIFF
--- a/source/HassIQState.mc
+++ b/source/HassIQState.mc
@@ -359,11 +359,11 @@ class HassIQState {
 			}
 
 			if (state.length() == 0 || state.equals(off) || state.equals(unknown)) {
-				// Nothing
+				color = Graphics.COLOR_DK_GRAY ;
 			} else if (state.equals(on)) {
-				title = "* " + title;
+				color = Graphics.COLOR_WHITE;
 			} else {
-				title = title + ":" + state;
+				color = Graphics.COLOR_DK_GRAY ;
 			}
 
 			entity[:title] = title;

--- a/source/HassIQState.mc
+++ b/source/HassIQState.mc
@@ -363,7 +363,8 @@ class HassIQState {
 			} else if (state.equals(on)) {
 				color = Graphics.COLOR_WHITE;
 			} else {
-				color = Graphics.COLOR_DK_GRAY ;
+				title = title + ": " + state;
+				color = Graphics.COLOR_WHITE;
 			}
 
 			entity[:title] = title;


### PR DESCRIPTION
Instead of identifying ON entities with an asterisk, this change makes ON entities display with the normal white text whilst displaying OFF entities with dark grey text