### PR TITLE
Load text size glitch fix

### DIFF
--- a/source/HassIQApp.mc
+++ b/source/HassIQApp.mc
@@ -10,6 +10,7 @@ class HassIQApp extends Application.AppBase {
 	}
 
 	function onStart(state) {
+		onSettingsChanged();
 		self.state.load(getProperty("state"));
 
 		var selected = getProperty("selected");
@@ -21,8 +22,6 @@ class HassIQApp extends Application.AppBase {
 				}
 			}
 		}
-
-		onSettingsChanged();
 	}
 
 	function onStop(state) {

--- a/source/HassIQState.mc
+++ b/source/HassIQState.mc
@@ -363,7 +363,8 @@ class HassIQState {
 			} else if (state.equals(on)) {
 				color = Graphics.COLOR_WHITE;
 			} else {
-				color = Graphics.COLOR_DK_GRAY ;
+				title = title + ": " + state;
+ 				color = Graphics.COLOR_WHITE;
 			}
 
 			entity[:title] = title;

--- a/source/HassIQState.mc
+++ b/source/HassIQState.mc
@@ -359,11 +359,11 @@ class HassIQState {
 			}
 
 			if (state.length() == 0 || state.equals(off) || state.equals(unknown)) {
-				// Nothing
+				color = Graphics.COLOR_DK_GRAY ;
 			} else if (state.equals(on)) {
-				title = "* " + title;
+				color = Graphics.COLOR_WHITE;
 			} else {
-				title = title + ":" + state;
+				color = Graphics.COLOR_DK_GRAY ;
 			}
 
 			entity[:title] = title;


### PR DESCRIPTION
If user has set text size to 0 (small), on re-opening the app the entities will briefly appear in size 1 (normal) text but squidged together whilst the entity states load, before then switching to the user-selected size. By moving onSettingsChanged to before entities are initially loaded, text size is loaded properly, text is rendered correctly from the start and the glitch does not occur.

PS - sorry, I had already included the changes for colours-representing-states in my master, so these are included in this pull request too - if you don't like this change then don't merge the hassiqstate.mc in this commit! As you can tell, I'm rubbish at GitHub!